### PR TITLE
warning: 'self_test_bit' may be used uninitialized

### DIFF
--- a/src/M5_BMM150.cpp
+++ b/src/M5_BMM150.cpp
@@ -1699,7 +1699,7 @@ static int16_t compensate_z(int16_t mag_data_z, uint16_t data_rhall, const struc
 static int8_t perform_normal_self_test(const struct bmm150_dev *dev)
 {
 	int8_t rslt;
-	uint8_t self_test_bit;
+	uint8_t self_test_bit = 0;
 
 	/* Triggers the start of normal self test */
 	rslt = enable_normal_self_test(&self_test_bit, dev);


### PR DESCRIPTION
There is no problem. But I get a warning.

```
.pio\libdeps\bmm150\M5_BMM150\src\M5_BMM150.cpp: In function 'int8_t bmm150_perform_self_test(uint8_t, bmm150_dev*)':
.pio\libdeps\bmm150\M5_BMM150\src\M5_BMM150.cpp:1707:27: warning: 'self_test_bit' may be used uninitialized in this function [-Wmaybe-uninitialized]
   if ((rslt == BMM150_OK) && (self_test_bit == 0)) {
                           ^
.pio\libdeps\bmm150\M5_BMM150\src\M5_BMM150.cpp:1702:10: note: 'self_test_bit' was declared here
  uint8_t self_test_bit;
```